### PR TITLE
npm command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In this exercise you will learn how to declare and use Javascript variables
 - Fork this repository and clone your forked version to your machine
 - Install dependencies by running the command below while in the project's root directory:
 
-  `npm ci`
+  `npm i`
 
 ## Instructions
 


### PR DESCRIPTION
`npm ci` is not a valid npm command
To install dependencies use `npm install` or the shorthand `npm i`